### PR TITLE
API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+openapi.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .idea
-openapi.json

--- a/README.md
+++ b/README.md
@@ -41,94 +41,19 @@ If you want to stop you just need to run the following command:
 $ make stop
 ```
 
-## API Resources
+## API Documentation
 
-### /v1/game/status
+The API documentation was on OpenAPI format.
 
-This resource will give you the game status based on game turns.
+To see the doc you can access `http://localhost:3002` on your browser.
 
-Request example:
-```bash
-Request
-POST http://localhost:3001/v1/game/status
+> Note: You must need to start project before it.
 
-Body:
-Content-Type: application/json
-"boardTurns": [
-    {
-        "team": "X",
-        "row": 1,
-        "column": 2
-    },
-    {
-        "team": "O",
-        "row": 0,
-        "column": 1
-    }
-]
-```
+If you prefer to see doc on other platform, you only need to import the `openapi.json`
+file to them.
 
-Response example when game is not over:
-```bash
-204 No Content
-```
-
-Response example when game is over and has a winner:
-```bash
-200 Ok
-
-{
-    "status": "gameover",
-    "message": "The X team is the winner!",
-    "board" : [
-        ["X", "O", "O"],
-        ["", "X", ""],
-        ["", "", "X"]
-    ]
-}
-```
-
-Response example when game is over in a draw:
-```bash
-200 Ok
-
-{
-    "status": "gameover",
-    "message": "Draw game!",
-    "board" : [
-        ["X", "O", "O"],
-        ["O", "X", "X"],
-        ["X", "O", "O"]
-    ]
-}
-```
-
-### /v1/bot/{team}/move
-
-This resource will give you the next BOT movement based on game board.
-
-Request example:
-```bash
-Request
-POST http://localhost:3001/v1/bot/O/move
-
-Body:
-Content-Type: application/json
-"board" : [
-        ["X", "O", ""],
-        ["X", "", ""],
-        ["", "", ""]
-    ]
-```
-Response example:
-```bash
-200 Ok
-
-{
-    "row": 0,
-    "column": 2,
-}
-```
+> Note: To generate a new version of API doc, you need to run `php bin/console app:generate-doc`
+on API root.
 
 ## Run tests
 

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -21,7 +21,8 @@
         "symfony/dotenv": "4.2.*",
         "symfony/flex": "^1.1",
         "symfony/framework-bundle": "4.2.*",
-        "symfony/yaml": "4.2.*"
+        "symfony/yaml": "4.2.*",
+        "zircote/swagger-php": "^3.0"
     },
     "config": {
         "preferred-install": {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,8 +4,130 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ae9d17f0ff4e7c0be6415fa975fbc36",
+    "content-hash": "78efef2bffb1ff19be2cf1731a2d596a",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/53120e0eb10355388d6ccbe462f1fea34ddadb24",
+                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2019-03-25T19:12:02+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
         {
             "name": "monolog/monolog",
             "version": "1.24.0",
@@ -1639,6 +1761,69 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2019-03-30T15:58:42+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "f10ab7f81d89dba97653a980cc90cf4b7b73f543"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/f10ab7f81d89dba97653a980cc90cf4b7b73f543",
+                "reference": "f10ab7f81d89dba97653a980cc90cf4b7b73f543",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "*",
+                "php": ">=7.0",
+                "symfony/finder": ">=2.2",
+                "symfony/yaml": ">=3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=6.3",
+                "squizlabs/php_codesniffer": ">=3.3",
+                "zendframework/zend-form": "<2.8"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com",
+                    "homepage": "http://www.zircote.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "http://bfanger.nl"
+                }
+            ],
+            "description": "swagger-php - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "time": "2018-11-16T15:04:29+00:00"
         }
     ],
     "packages-dev": [

--- a/backend/config/routes/annotations.yaml
+++ b/backend/config/routes/annotations.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../src/Controller/
+    type: annotation

--- a/backend/src/Command/GenerateDoc.php
+++ b/backend/src/Command/GenerateDoc.php
@@ -1,0 +1,50 @@
+<?php
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use OpenApi;
+
+class GenerateDoc extends Command
+{
+    /** @var string */
+    private $path = __DIR__ . '/../../../openapi.json';
+
+    /** @var string */
+    protected static $defaultName = 'app:generate-doc';
+
+    /**
+     * @return void
+     */
+    protected function configure() : void
+    {
+        $this->setDescription('Generate documentation in OpenAPI format.');
+        $this->setHelp('This command will help you to generate the API documentation.');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) : void
+    {
+        $output->writeln([
+            'Generating doc',
+            '=============='
+        ]);
+        $this->generate();
+        $output->writeln('Done!');
+    }
+
+    /**
+     * @return void
+     */
+    private function generate() : void
+    {
+        $openapi = OpenApi\scan(__DIR__ . '/../');
+        file_put_contents($this->path, $openapi->toJson());
+    }
+}

--- a/backend/src/Controller/GameController.php
+++ b/backend/src/Controller/GameController.php
@@ -9,7 +9,17 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Info(
+ *     title="Tic Tac Toe",
+ *     version="0.1",
+ *     @OA\Contact(
+ *         email="contato@henriqueholanda.com.br"
+ *     ),
+ * )
+ */
 class GameController
 {
     /** @var Game */
@@ -29,9 +39,12 @@ class GameController
     }
 
     /**
-     * @param Request $request
-     *
-     * @return Response
+     * @OA\Post(
+     *     path="/v1/game/status",
+     *     @OA\Response(response="200", description="Game is over and have a winner or is a draw"),
+     *     @OA\Response(response="204", description="Game is not over"),
+     *     @OA\Response(response="422", description="Validation error")
+     * )
      */
     public function status(Request $request) : Response
     {

--- a/backend/src/Controller/GameController.php
+++ b/backend/src/Controller/GameController.php
@@ -41,6 +41,7 @@ class GameController
     /**
      * @OA\Post(
      *     path="/v1/game/status",
+     *     description="This resource will give you the game status based on game turns.",
      *     @OA\Response(response="200", description="Game is over and have a winner or is a draw"),
      *     @OA\Response(response="204", description="Game is not over"),
      *     @OA\Response(response="422", description="Validation error")

--- a/backend/src/Controller/MoveController.php
+++ b/backend/src/Controller/MoveController.php
@@ -6,6 +6,7 @@ use App\Model\Move\MoveInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use OpenApi\Annotations as OA;
 
 class MoveController
 {
@@ -18,10 +19,16 @@ class MoveController
     }
 
     /**
-     * @param Request $request
-     * @param string $team
-     *
-     * @return Response
+     * @OA\Post(
+     *     path="/v1/bot/{team}/move",
+     *     @OA\Parameter(name="team",
+     *         in="path",
+     *         required=true,
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(response="200", description="New bot movement"),
+     *     @OA\Response(response="400", description="Error when bot try to move")
+     * )
      */
     public function move(Request $request, string $team) : Response
     {

--- a/backend/src/Controller/MoveController.php
+++ b/backend/src/Controller/MoveController.php
@@ -21,6 +21,7 @@ class MoveController
     /**
      * @OA\Post(
      *     path="/v1/bot/{team}/move",
+     *     description="This resource will give you the next BOT movement based on game board.",
      *     @OA\Parameter(name="team",
      *         in="path",
      *         required=true,

--- a/backend/symfony.lock
+++ b/backend/symfony.lock
@@ -2,8 +2,23 @@
     "composer/xdebug-handler": {
         "version": "1.3.2"
     },
+    "doctrine/annotations": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "cb4152ebcadbe620ea2261da1a1c5a9b8cea7672"
+        },
+        "files": [
+            "config/routes/annotations.yaml"
+        ]
+    },
     "doctrine/instantiator": {
         "version": "1.2.0"
+    },
+    "doctrine/lexer": {
+        "version": "v1.0.1"
     },
     "jean85/pretty-package-versions": {
         "version": "1.2"
@@ -279,5 +294,8 @@
     },
     "webmozart/assert": {
         "version": "1.4.0"
+    },
+    "zircote/swagger-php": {
+        "version": "3.0.2"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,15 @@ services:
     networks:
       - tic-tac-toe
 
+  documentation:
+    image: swaggerapi/swagger-ui
+    container_name: tic-tac-toe-doc
+    ports:
+      - 3002:8080
+    volumes:
+      - ./openapi.json:/doc/openapi.json
+    environment:
+      - SWAGGER_JSON=/doc/openapi.json
+
 networks:
   tic-tac-toe:

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,53 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Tic Tac Toe",
+        "contact": {
+            "email": "contato@henriqueholanda.com.br"
+        },
+        "version": "0.1"
+    },
+    "paths": {
+        "/v1/game/status": {
+            "post": {
+                "description": "This resource will give you the game status based on game turns.",
+                "operationId": "App\\Controller\\GameController::status",
+                "responses": {
+                    "200": {
+                        "description": "Game is over and have a winner or is a draw"
+                    },
+                    "204": {
+                        "description": "Game is not over"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                }
+            }
+        },
+        "/v1/bot/{team}/move": {
+            "post": {
+                "description": "This resource will give you the next BOT movement based on game board.",
+                "operationId": "App\\Controller\\MoveController::move",
+                "parameters": [
+                    {
+                        "name": "team",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "New bot movement"
+                    },
+                    "400": {
+                        "description": "Error when bot try to move"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
On this change I'm implementing the generation of API documentation
on OpenAPI format.

At this moment I'm only implementing the basic structure to generate the
documentation, only with the routes and response codes. To the next
steps I'll implement the other stuffs (like models).

I'm creating a command to generate a JSON file with the documentation.
To use it, you only need to run `php bin/console app:generate-doc` on
API root.

I'm also creating a container to show the API documentation
on OpenAPI format using SwaggerUI.